### PR TITLE
net/gve: support 4K ring size only for DQO

### DIFF
--- a/base/gve_adminq.c
+++ b/base/gve_adminq.c
@@ -516,11 +516,11 @@ static int gve_adminq_create_tx_queue(struct gve_priv *priv, u32 queue_index)
 		cmd.create_tx_queue.queue_page_list_id = cpu_to_be32(qpl_id);
 	} else {
 		cmd.create_tx_queue.tx_ring_size =
-			cpu_to_be16(priv->tx_desc_cnt);
+			cpu_to_be16(txq->nb_tx_desc);
 		cmd.create_tx_queue.tx_comp_ring_addr =
 			cpu_to_be64(txq->compl_ring_phys_addr);
 		cmd.create_tx_queue.tx_comp_ring_size =
-			cpu_to_be16(priv->tx_compq_size * DQO_TX_MULTIPLIER);
+			cpu_to_be16(txq->sw_size);
 	}
 
 	return gve_adminq_issue_cmd(priv, &cmd);
@@ -566,7 +566,7 @@ static int gve_adminq_create_rx_queue(struct gve_priv *priv, u32 queue_index)
 		cmd.create_rx_queue.packet_buffer_size = cpu_to_be16(rxq->rx_buf_len);
 	} else {
 		cmd.create_rx_queue.rx_ring_size =
-			cpu_to_be16(priv->rx_desc_cnt);
+			cpu_to_be16(rxq->nb_rx_desc);
 		cmd.create_rx_queue.rx_desc_ring_addr =
 			cpu_to_be64(rxq->compl_ring_phys_addr);
 		cmd.create_rx_queue.rx_data_ring_addr =
@@ -574,7 +574,7 @@ static int gve_adminq_create_rx_queue(struct gve_priv *priv, u32 queue_index)
 		cmd.create_rx_queue.packet_buffer_size =
 			cpu_to_be16(rxq->rx_buf_len);
 		cmd.create_rx_queue.rx_buff_ring_size =
-			cpu_to_be16(priv->rx_bufq_size);
+			cpu_to_be16(rxq->nb_rx_desc);
 		cmd.create_rx_queue.enable_rsc = !!(priv->enable_rsc);
 	}
 

--- a/gve_ethdev.c
+++ b/gve_ethdev.c
@@ -333,14 +333,14 @@ gve_dev_info_get(struct rte_eth_dev *dev, struct rte_eth_dev_info *dev_info)
 
 	dev_info->default_rxportconf.ring_size = priv->rx_desc_cnt;
 	dev_info->rx_desc_lim = (struct rte_eth_desc_lim) {
-		.nb_max = priv->rx_desc_cnt,
+		.nb_max = gve_is_gqi(priv) ? priv->rx_desc_cnt : GVE_MAX_QUEUE_SIZE_DQO,
 		.nb_min = priv->rx_desc_cnt,
 		.nb_align = 1,
 	};
 
 	dev_info->default_txportconf.ring_size = priv->tx_desc_cnt;
 	dev_info->tx_desc_lim = (struct rte_eth_desc_lim) {
-		.nb_max = priv->tx_desc_cnt,
+		.nb_max = gve_is_gqi(priv) ? priv->tx_desc_cnt : GVE_MAX_QUEUE_SIZE_DQO,
 		.nb_min = priv->tx_desc_cnt,
 		.nb_align = 1,
 	};
@@ -614,53 +614,17 @@ gve_teardown_device_resources(struct gve_priv *priv)
 	gve_clear_device_resources_ok(priv);
 }
 
-static uint8_t
-pci_dev_find_capability(struct rte_pci_device *pdev, int cap)
-{
-	uint8_t pos, id;
-	uint16_t ent;
-	int loops;
-	int ret;
-
-	ret = rte_pci_read_config(pdev, &pos, sizeof(pos), PCI_CAPABILITY_LIST);
-	if (ret != sizeof(pos))
-		return 0;
-
-	loops = (PCI_CFG_SPACE_SIZE - PCI_STD_HEADER_SIZEOF) / PCI_CAP_SIZEOF;
-
-	while (pos && loops--) {
-		ret = rte_pci_read_config(pdev, &ent, sizeof(ent), pos);
-		if (ret != sizeof(ent))
-			return 0;
-
-		id = ent & 0xff;
-		if (id == 0xff)
-			break;
-
-		if (id == cap)
-			return pos;
-
-		pos = (ent >> 8);
-	}
-
-	return 0;
-}
-
 static int
 pci_dev_msix_vec_count(struct rte_pci_device *pdev)
 {
-	uint8_t msix_cap = pci_dev_find_capability(pdev, PCI_CAP_ID_MSIX);
+	off_t msix_pos = rte_pci_find_capability(pdev, RTE_PCI_CAP_ID_MSIX);
 	uint16_t control;
-	int ret;
 
-	if (!msix_cap)
-		return 0;
+	if (msix_pos > 0 && rte_pci_read_config(pdev, &control, sizeof(control),
+			msix_pos + RTE_PCI_MSIX_FLAGS) == sizeof(control))
+		return (control & RTE_PCI_MSIX_FLAGS_QSIZE) + 1;
 
-	ret = rte_pci_read_config(pdev, &control, sizeof(control), msix_cap + PCI_MSIX_FLAGS);
-	if (ret != sizeof(control))
-		return 0;
-
-	return (control & PCI_MSIX_FLAGS_QSIZE) + 1;
+	return 0;
 }
 
 static int

--- a/gve_ethdev.h
+++ b/gve_ethdev.h
@@ -8,24 +8,12 @@
 #include <ethdev_driver.h>
 #include <ethdev_pci.h>
 #include <rte_ether.h>
+#include <rte_pci.h>
 
 #include "base/gve.h"
 
 /* TODO: this is a workaround to ensure that Tx complq is enough */
 #define DQO_TX_MULTIPLIER 4
-
-/*
- * Following macros are derived from linux/pci_regs.h, however,
- * we can't simply include that header here, as there is no such
- * file for non-Linux platform.
- */
-#define PCI_CFG_SPACE_SIZE	256
-#define PCI_CAPABILITY_LIST	0x34	/* Offset of first capability list entry */
-#define PCI_STD_HEADER_SIZEOF	64
-#define PCI_CAP_SIZEOF		4
-#define PCI_CAP_ID_MSIX		0x11	/* MSI-X */
-#define PCI_MSIX_FLAGS		2	/* Message Control */
-#define PCI_MSIX_FLAGS_QSIZE	0x07FF	/* Table size */
 
 #define GVE_DEFAULT_RX_FREE_THRESH   64
 #define GVE_DEFAULT_TX_FREE_THRESH   32
@@ -35,6 +23,7 @@
 #define GVE_RX_BUF_ALIGN_DQO        128
 #define GVE_RX_MIN_BUF_SIZE_DQO    1024
 #define GVE_RX_MAX_BUF_SIZE_DQO    ((16 * 1024) - GVE_RX_BUF_ALIGN_DQO)
+#define GVE_MAX_QUEUE_SIZE_DQO     4096
 
 #define GVE_RX_BUF_ALIGN_GQI       2048
 #define GVE_RX_MIN_BUF_SIZE_GQI    2048

--- a/gve_rx_dqo.c
+++ b/gve_rx_dqo.c
@@ -223,12 +223,6 @@ gve_rx_queue_setup_dqo(struct rte_eth_dev *dev, uint16_t queue_id,
 	uint32_t mbuf_len;
 	int err = 0;
 
-	if (nb_desc != hw->rx_desc_cnt) {
-		PMD_DRV_LOG(WARNING, "gve doesn't support nb_desc config, use hw nb_desc %u.",
-			    hw->rx_desc_cnt);
-	}
-	nb_desc = hw->rx_desc_cnt;
-
 	/* Free memory if needed */
 	if (dev->data->rx_queues[queue_id]) {
 		gve_rx_queue_release_dqo(dev, queue_id);

--- a/gve_tx_dqo.c
+++ b/gve_tx_dqo.c
@@ -268,12 +268,6 @@ gve_tx_queue_setup_dqo(struct rte_eth_dev *dev, uint16_t queue_id,
 	uint16_t sw_size;
 	int err = 0;
 
-	if (nb_desc != hw->tx_desc_cnt) {
-		PMD_DRV_LOG(WARNING, "gve doesn't support nb_desc config, use hw nb_desc %u.",
-			    hw->tx_desc_cnt);
-	}
-	nb_desc = hw->tx_desc_cnt;
-
 	/* Free memory if needed. */
 	if (dev->data->tx_queues[queue_id]) {
 		gve_tx_queue_release_dqo(dev, queue_id);


### PR DESCRIPTION
Bump up the dpdk dqo driver ring size to 4096.
The queue size is controlled by queue_setup method.

pci: use MSIX constants

Sync to dpdk change: 7bb1168d984aaa7e204c52d13c4701eac0f82989