### PR TITLE
Update GitHub Driver to be in sync with dpdk-next-net

### DIFF
--- a/base/gve_adminq.c
+++ b/base/gve_adminq.c
@@ -11,7 +11,7 @@
 #define GVE_ADMINQ_SLEEP_LEN		20
 #define GVE_MAX_ADMINQ_EVENT_COUNTER_CHECK	100
 
-#define GVE_DEVICE_OPTION_ERROR_FMT "%s option error:\n Expected: length=%d, feature_mask=%x.\n Actual: length=%d, feature_mask=%x."
+#define GVE_DEVICE_OPTION_ERROR_FMT "%s option error: Expected: length=%d, feature_mask=%x. Actual: length=%d, feature_mask=%x."
 
 #define GVE_DEVICE_OPTION_TOO_BIG_FMT "Length of %s option larger than expected. Possible older version of guest driver."
 
@@ -736,7 +736,7 @@ gve_set_max_desc_cnt(struct gve_priv *priv,
 {
 	if (priv->queue_format == GVE_DQO_RDA_FORMAT) {
 		PMD_DRV_LOG(DEBUG, "Overriding max ring size from device for DQ "
-			    "queue format to 4096.\n");
+			    "queue format to 4096.");
 		priv->max_rx_desc_cnt = GVE_MAX_QUEUE_SIZE_DQO;
 		priv->max_tx_desc_cnt = GVE_MAX_QUEUE_SIZE_DQO;
 		return;

--- a/base/gve_adminq.c
+++ b/base/gve_adminq.c
@@ -540,6 +540,7 @@ static int gve_adminq_create_tx_queue(struct gve_priv *priv, u32 queue_index)
 			cpu_to_be64(txq->qres_mz->iova),
 		.tx_ring_addr = cpu_to_be64(txq->tx_ring_phys_addr),
 		.ntfy_id = cpu_to_be32(txq->ntfy_id),
+		.tx_ring_size = cpu_to_be16(txq->nb_tx_desc),
 	};
 
 	if (gve_is_gqi(priv)) {
@@ -548,8 +549,6 @@ static int gve_adminq_create_tx_queue(struct gve_priv *priv, u32 queue_index)
 
 		cmd.create_tx_queue.queue_page_list_id = cpu_to_be32(qpl_id);
 	} else {
-		cmd.create_tx_queue.tx_ring_size =
-			cpu_to_be16(txq->nb_tx_desc);
 		cmd.create_tx_queue.tx_comp_ring_addr =
 			cpu_to_be64(txq->compl_ring_phys_addr);
 		cmd.create_tx_queue.tx_comp_ring_size =
@@ -584,6 +583,7 @@ static int gve_adminq_create_rx_queue(struct gve_priv *priv, u32 queue_index)
 		.queue_id = cpu_to_be32(queue_index),
 		.ntfy_id = cpu_to_be32(rxq->ntfy_id),
 		.queue_resources_addr = cpu_to_be64(rxq->qres_mz->iova),
+		.rx_ring_size = cpu_to_be16(rxq->nb_rx_desc),
 	};
 
 	if (gve_is_gqi(priv)) {
@@ -598,8 +598,6 @@ static int gve_adminq_create_rx_queue(struct gve_priv *priv, u32 queue_index)
 		cmd.create_rx_queue.queue_page_list_id = cpu_to_be32(qpl_id);
 		cmd.create_rx_queue.packet_buffer_size = cpu_to_be16(rxq->rx_buf_len);
 	} else {
-		cmd.create_rx_queue.rx_ring_size =
-			cpu_to_be16(rxq->nb_rx_desc);
 		cmd.create_rx_queue.rx_desc_ring_addr =
 			cpu_to_be64(rxq->compl_ring_phys_addr);
 		cmd.create_rx_queue.rx_data_ring_addr =

--- a/base/gve_adminq.c
+++ b/base/gve_adminq.c
@@ -837,14 +837,7 @@ int gve_adminq_describe_device(struct gve_priv *priv)
 	PMD_DRV_LOG(INFO, "MAC addr: " RTE_ETHER_ADDR_PRT_FMT,
 		    RTE_ETHER_ADDR_BYTES(&priv->dev_addr));
 	priv->tx_pages_per_qpl = be16_to_cpu(descriptor->tx_pages_per_qpl);
-	priv->rx_data_slot_cnt = be16_to_cpu(descriptor->rx_pages_per_qpl);
 
-	if (gve_is_gqi(priv) && priv->rx_data_slot_cnt < priv->rx_desc_cnt) {
-		PMD_DRV_LOG(ERR,
-			    "rx_data_slot_cnt cannot be smaller than rx_desc_cnt, setting rx_desc_cnt down to %d",
-			    priv->rx_data_slot_cnt);
-		priv->rx_desc_cnt = priv->rx_data_slot_cnt;
-	}
 	priv->default_num_queues = be16_to_cpu(descriptor->default_num_queues);
 
 	gve_enable_supported_features(priv, supported_features_mask,

--- a/base/gve_adminq.h
+++ b/base/gve_adminq.h
@@ -110,13 +110,20 @@ struct gve_device_option_dqo_rda {
 
 GVE_CHECK_STRUCT_LEN(8, gve_device_option_dqo_rda);
 
-struct gve_device_option_modify_ring {
-	__be32 supported_features_mask;
-	__be16 max_rx_ring_size;
-	__be16 max_tx_ring_size;
+struct gve_ring_size_bound {
+	__be16 rx;
+	__be16 tx;
 };
 
-GVE_CHECK_STRUCT_LEN(8, gve_device_option_modify_ring);
+GVE_CHECK_STRUCT_LEN(4, gve_ring_size_bound);
+
+struct gve_device_option_modify_ring {
+	__be32 supported_features_mask;
+	struct gve_ring_size_bound max_ring_size;
+	struct gve_ring_size_bound min_ring_size;
+};
+
+GVE_CHECK_STRUCT_LEN(12, gve_device_option_modify_ring);
 
 struct gve_device_option_jumbo_frames {
 	__be32 supported_features_mask;

--- a/base/gve_adminq.h
+++ b/base/gve_adminq.h
@@ -110,6 +110,14 @@ struct gve_device_option_dqo_rda {
 
 GVE_CHECK_STRUCT_LEN(8, gve_device_option_dqo_rda);
 
+struct gve_device_option_modify_ring {
+	__be32 supported_features_mask;
+	__be16 max_rx_ring_size;
+	__be16 max_tx_ring_size;
+};
+
+GVE_CHECK_STRUCT_LEN(8, gve_device_option_modify_ring);
+
 struct gve_device_option_jumbo_frames {
 	__be32 supported_features_mask;
 	__be16 max_mtu;
@@ -131,6 +139,7 @@ enum gve_dev_opt_id {
 	GVE_DEV_OPT_ID_GQI_RDA = 0x2,
 	GVE_DEV_OPT_ID_GQI_QPL = 0x3,
 	GVE_DEV_OPT_ID_DQO_RDA = 0x4,
+	GVE_DEV_OPT_ID_MODIFY_RING = 0x6,
 	GVE_DEV_OPT_ID_JUMBO_FRAMES = 0x8,
 };
 
@@ -139,10 +148,12 @@ enum gve_dev_opt_req_feat_mask {
 	GVE_DEV_OPT_REQ_FEAT_MASK_GQI_RDA = 0x0,
 	GVE_DEV_OPT_REQ_FEAT_MASK_GQI_QPL = 0x0,
 	GVE_DEV_OPT_REQ_FEAT_MASK_DQO_RDA = 0x0,
+	GVE_DEV_OPT_REQ_FEAT_MASK_MODIFY_RING = 0x0,
 	GVE_DEV_OPT_REQ_FEAT_MASK_JUMBO_FRAMES = 0x0,
 };
 
 enum gve_sup_feature_mask {
+	GVE_SUP_MODIFY_RING_MASK = 1 << 0,
 	GVE_SUP_JUMBO_FRAMES_MASK = 1 << 2,
 };
 

--- a/base/gve_osdep.h
+++ b/base/gve_osdep.h
@@ -29,22 +29,46 @@
 #include <sys/utsname.h>
 #endif
 
-typedef uint8_t u8;
-typedef uint16_t u16;
-typedef uint32_t u32;
-typedef uint64_t u64;
+#ifndef u8
+#define u8 uint8_t
+#endif
+#ifndef u16
+#define u16 uint16_t
+#endif
+#ifndef u32
+#define u32 uint32_t
+#endif
+#ifndef u64
+#define u64 uint64_t
+#endif
 
-typedef rte_be16_t __sum16;
+#ifndef __sum16
+#define __sum16 rte_be16_t
+#endif
 
-typedef rte_be16_t __be16;
-typedef rte_be32_t __be32;
-typedef rte_be64_t __be64;
+#ifndef __be16
+#define __be16 rte_be16_t
+#endif
+#ifndef __be32
+#define __be32 rte_be32_t
+#endif
+#ifndef __be64
+#define __be64 rte_be64_t
+#endif
 
-typedef rte_le16_t __le16;
-typedef rte_le32_t __le32;
-typedef rte_le64_t __le64;
+#ifndef __le16
+#define __le16 rte_le16_t
+#endif
+#ifndef __le32
+#define __le32 rte_le32_t
+#endif
+#ifndef __le64
+#define __le64 rte_le64_t
+#endif
 
-typedef rte_iova_t dma_addr_t;
+#ifndef dma_addr_t
+#define dma_addr_t rte_iova_t
+#endif
 
 #define ETH_MIN_MTU	RTE_ETHER_MIN_MTU
 #define ETH_ALEN	RTE_ETHER_ADDR_LEN

--- a/base/gve_osdep.h
+++ b/base/gve_osdep.h
@@ -135,7 +135,7 @@ struct gve_dma_mem {
 static inline void *
 gve_alloc_dma_mem(struct gve_dma_mem *mem, u64 size)
 {
-	static uint16_t gve_dma_memzone_id;
+	static RTE_ATOMIC(uint16_t) gve_dma_memzone_id;
 	const struct rte_memzone *mz = NULL;
 	char z_name[RTE_MEMZONE_NAMESIZE];
 
@@ -143,7 +143,7 @@ gve_alloc_dma_mem(struct gve_dma_mem *mem, u64 size)
 		return NULL;
 
 	snprintf(z_name, sizeof(z_name), "gve_dma_%u",
-		 __atomic_fetch_add(&gve_dma_memzone_id, 1, __ATOMIC_RELAXED));
+		 rte_atomic_fetch_add_explicit(&gve_dma_memzone_id, 1, rte_memory_order_relaxed));
 	mz = rte_memzone_reserve_aligned(z_name, size, SOCKET_ID_ANY,
 					 RTE_MEMZONE_IOVA_CONTIG,
 					 PAGE_SIZE);

--- a/gve_ethdev.c
+++ b/gve_ethdev.c
@@ -1185,8 +1185,18 @@ gve_dev_init(struct rte_eth_dev *eth_dev)
 	rte_be32_t *db_bar;
 	int err;
 
-	if (rte_eal_process_type() != RTE_PROC_PRIMARY)
+	if (rte_eal_process_type() != RTE_PROC_PRIMARY) {
+		if (gve_is_gqi(priv)) {
+			gve_set_rx_function(eth_dev);
+			gve_set_tx_function(eth_dev);
+			eth_dev->dev_ops = &gve_eth_dev_ops;
+		} else {
+			gve_set_rx_function_dqo(eth_dev);
+			gve_set_tx_function_dqo(eth_dev);
+			eth_dev->dev_ops = &gve_eth_dev_ops_dqo;
+		}
 		return 0;
+	}
 
 	pci_dev = RTE_DEV_TO_PCI(eth_dev->device);
 

--- a/gve_ethdev.c
+++ b/gve_ethdev.c
@@ -510,19 +510,15 @@ gve_dev_info_get(struct rte_eth_dev *dev, struct rte_eth_dev_info *dev_info)
 
 	dev_info->default_rxportconf.ring_size = priv->default_rx_desc_cnt;
 	dev_info->rx_desc_lim = (struct rte_eth_desc_lim) {
-		.nb_max = gve_is_gqi(priv) ?
-			priv->default_rx_desc_cnt :
-			GVE_MAX_QUEUE_SIZE_DQO,
-		.nb_min = priv->default_rx_desc_cnt,
+		.nb_max = priv->max_rx_desc_cnt,
+		.nb_min = priv->min_rx_desc_cnt,
 		.nb_align = 1,
 	};
 
 	dev_info->default_txportconf.ring_size = priv->default_tx_desc_cnt;
 	dev_info->tx_desc_lim = (struct rte_eth_desc_lim) {
-		.nb_max = gve_is_gqi(priv) ?
-			priv->default_tx_desc_cnt :
-			GVE_MAX_QUEUE_SIZE_DQO,
-		.nb_min = priv->default_tx_desc_cnt,
+		.nb_max = priv->max_tx_desc_cnt,
+		.nb_min = priv->min_tx_desc_cnt,
 		.nb_align = 1,
 	};
 

--- a/gve_ethdev.c
+++ b/gve_ethdev.c
@@ -508,17 +508,21 @@ gve_dev_info_get(struct rte_eth_dev *dev, struct rte_eth_dev_info *dev_info)
 		.offloads = 0,
 	};
 
-	dev_info->default_rxportconf.ring_size = priv->rx_desc_cnt;
+	dev_info->default_rxportconf.ring_size = priv->default_rx_desc_cnt;
 	dev_info->rx_desc_lim = (struct rte_eth_desc_lim) {
-		.nb_max = gve_is_gqi(priv) ? priv->rx_desc_cnt : GVE_MAX_QUEUE_SIZE_DQO,
-		.nb_min = priv->rx_desc_cnt,
+		.nb_max = gve_is_gqi(priv) ?
+			priv->default_rx_desc_cnt :
+			GVE_MAX_QUEUE_SIZE_DQO,
+		.nb_min = priv->default_rx_desc_cnt,
 		.nb_align = 1,
 	};
 
-	dev_info->default_txportconf.ring_size = priv->tx_desc_cnt;
+	dev_info->default_txportconf.ring_size = priv->default_tx_desc_cnt;
 	dev_info->tx_desc_lim = (struct rte_eth_desc_lim) {
-		.nb_max = gve_is_gqi(priv) ? priv->tx_desc_cnt : GVE_MAX_QUEUE_SIZE_DQO,
-		.nb_min = priv->tx_desc_cnt,
+		.nb_max = gve_is_gqi(priv) ?
+			priv->default_tx_desc_cnt :
+			GVE_MAX_QUEUE_SIZE_DQO,
+		.nb_min = priv->default_tx_desc_cnt,
 		.nb_align = 1,
 	};
 
@@ -1088,6 +1092,15 @@ free_cnt_array:
 	return err;
 }
 
+static void
+gve_set_default_ring_size_bounds(struct gve_priv *priv)
+{
+	priv->max_tx_desc_cnt = GVE_DEFAULT_MAX_RING_SIZE;
+	priv->max_rx_desc_cnt = GVE_DEFAULT_MAX_RING_SIZE;
+	priv->min_tx_desc_cnt = GVE_DEFAULT_MIN_TX_RING_SIZE;
+	priv->min_rx_desc_cnt = GVE_DEFAULT_MIN_RX_RING_SIZE;
+}
+
 static int
 gve_init_priv(struct gve_priv *priv, bool skip_describe_device)
 {
@@ -1105,6 +1118,9 @@ gve_init_priv(struct gve_priv *priv, bool skip_describe_device)
 		PMD_DRV_LOG(ERR, "Could not verify driver compatibility: err=%d", err);
 		goto free_adminq;
 	}
+
+	/* Set default descriptor counts */
+	gve_set_default_ring_size_bounds(priv);
 
 	if (skip_describe_device)
 		goto setup_device;

--- a/gve_ethdev.c
+++ b/gve_ethdev.c
@@ -77,8 +77,7 @@ gve_free_qpls(struct gve_priv *priv)
 		return;
 
 	for (i = 0; i < nb_txqs + nb_rxqs; i++) {
-		if (priv->qpl[i].mz != NULL)
-			rte_memzone_free(priv->qpl[i].mz);
+		rte_memzone_free(priv->qpl[i].mz);
 		rte_free(priv->qpl[i].page_buses);
 	}
 

--- a/gve_ethdev.h
+++ b/gve_ethdev.h
@@ -242,8 +242,7 @@ struct gve_priv {
 	uint16_t max_rx_desc_cnt;
 	uint16_t tx_desc_cnt; /* txq size */
 	uint16_t rx_desc_cnt; /* rxq size */
-	uint16_t tx_pages_per_qpl; /* tx buffer length */
-	uint16_t rx_data_slot_cnt; /* rx buffer length */
+	uint16_t tx_pages_per_qpl;
 
 	/* Only valid for DQO_RDA queue format */
 	uint16_t tx_compq_size; /* tx completion queue size */

--- a/gve_ethdev.h
+++ b/gve_ethdev.h
@@ -15,19 +15,23 @@
 /* TODO: this is a workaround to ensure that Tx complq is enough */
 #define DQO_TX_MULTIPLIER 4
 
-#define GVE_DEFAULT_RX_FREE_THRESH   64
-#define GVE_DEFAULT_TX_FREE_THRESH   32
-#define GVE_DEFAULT_TX_RS_THRESH     32
-#define GVE_TX_MAX_FREE_SZ          512
+#define GVE_DEFAULT_MAX_RING_SIZE	1024
+#define GVE_DEFAULT_MIN_RX_RING_SIZE	512
+#define GVE_DEFAULT_MIN_TX_RING_SIZE	256
 
-#define GVE_RX_BUF_ALIGN_DQO        128
-#define GVE_RX_MIN_BUF_SIZE_DQO    1024
-#define GVE_RX_MAX_BUF_SIZE_DQO    ((16 * 1024) - GVE_RX_BUF_ALIGN_DQO)
-#define GVE_MAX_QUEUE_SIZE_DQO     4096
+#define GVE_DEFAULT_RX_FREE_THRESH	64
+#define GVE_DEFAULT_TX_FREE_THRESH	32
+#define GVE_DEFAULT_TX_RS_THRESH	32
+#define GVE_TX_MAX_FREE_SZ		512
 
-#define GVE_RX_BUF_ALIGN_GQI       2048
-#define GVE_RX_MIN_BUF_SIZE_GQI    2048
-#define GVE_RX_MAX_BUF_SIZE_GQI    4096
+#define GVE_RX_BUF_ALIGN_DQO		128
+#define GVE_RX_MIN_BUF_SIZE_DQO		1024
+#define GVE_RX_MAX_BUF_SIZE_DQO		((16 * 1024) - GVE_RX_BUF_ALIGN_DQO)
+#define GVE_MAX_QUEUE_SIZE_DQO		4096
+
+#define GVE_RX_BUF_ALIGN_GQI		2048
+#define GVE_RX_MIN_BUF_SIZE_GQI		2048
+#define GVE_RX_MAX_BUF_SIZE_GQI		4096
 
 #define GVE_RSS_HASH_KEY_SIZE 40
 #define GVE_RSS_INDIR_SIZE 128
@@ -238,10 +242,17 @@ struct gve_priv {
 	const struct rte_memzone *cnt_array_mz;
 
 	uint16_t num_event_counters;
+
+	/* TX ring size default and limits. */
+	uint16_t default_tx_desc_cnt;
 	uint16_t max_tx_desc_cnt;
+	uint16_t min_tx_desc_cnt;
+
+	/* RX ring size default and limits. */
+	uint16_t default_rx_desc_cnt;
 	uint16_t max_rx_desc_cnt;
-	uint16_t tx_desc_cnt; /* txq size */
-	uint16_t rx_desc_cnt; /* rxq size */
+	uint16_t min_rx_desc_cnt;
+
 	uint16_t tx_pages_per_qpl;
 
 	/* Only valid for DQO_RDA queue format */

--- a/gve_ethdev.h
+++ b/gve_ethdev.h
@@ -36,6 +36,10 @@
 		RTE_MBUF_F_TX_L4_MASK  |	\
 		RTE_MBUF_F_TX_TCP_SEG)
 
+#define GVE_TX_CKSUM_OFFLOAD_MASK_DQO (		\
+		GVE_TX_CKSUM_OFFLOAD_MASK |	\
+		RTE_MBUF_F_TX_IP_CKSUM)
+
 #define GVE_RTE_RSS_OFFLOAD_ALL (	\
 	RTE_ETH_RSS_IPV4 |		\
 	RTE_ETH_RSS_NONFRAG_IPV4_TCP |	\
@@ -299,6 +303,7 @@ struct gve_priv {
 	uint16_t stats_end_idx; /* end index of array of stats written by NIC */
 
 	struct gve_rss_config rss_config;
+	struct gve_ptype_lut *ptype_lut_dqo;
 };
 
 static inline bool

--- a/gve_ethdev.h
+++ b/gve_ethdev.h
@@ -238,6 +238,8 @@ struct gve_priv {
 	const struct rte_memzone *cnt_array_mz;
 
 	uint16_t num_event_counters;
+	uint16_t max_tx_desc_cnt;
+	uint16_t max_rx_desc_cnt;
 	uint16_t tx_desc_cnt; /* txq size */
 	uint16_t rx_desc_cnt; /* rxq size */
 	uint16_t tx_pages_per_qpl; /* tx buffer length */

--- a/gve_ethdev.h
+++ b/gve_ethdev.h
@@ -47,6 +47,10 @@
 	RTE_ETH_RSS_NONFRAG_IPV6_UDP |	\
 	RTE_ETH_RSS_IPV6_UDP_EX)
 
+#define GVE_TX_CKSUM_OFFLOAD_MASK (		\
+		RTE_MBUF_F_TX_L4_MASK  |	\
+		RTE_MBUF_F_TX_TCP_SEG)
+
 /* A list of pages registered with the device during setup and used by a queue
  * as buffers
  */

--- a/gve_ethdev.h
+++ b/gve_ethdev.h
@@ -292,8 +292,6 @@ struct gve_priv {
 	uint16_t max_mtu;
 	struct rte_ether_addr dev_addr; /* mac address */
 
-	struct gve_queue_page_list *qpl;
-
 	struct gve_tx_queue **txqs;
 	struct gve_rx_queue **rxqs;
 
@@ -419,6 +417,13 @@ gve_set_rx_function(struct rte_eth_dev *dev);
 
 void
 gve_set_tx_function(struct rte_eth_dev *dev);
+
+struct gve_queue_page_list *
+gve_setup_queue_page_list(struct gve_priv *priv, uint16_t queue_id, bool is_rx,
+	uint32_t num_pages);
+int
+gve_teardown_queue_page_list(struct gve_priv *priv,
+	struct gve_queue_page_list *qpl);
 
 /* Below functions are used for DQO */
 

--- a/gve_logs.h
+++ b/gve_logs.h
@@ -6,9 +6,9 @@
 #define _GVE_LOGS_H_
 
 extern int gve_logtype_driver;
+#define RTE_LOGTYPE_GVE_DRIVER gve_logtype_driver
 
-#define PMD_DRV_LOG(level, fmt, args...) \
-	rte_log(RTE_LOG_ ## level, gve_logtype_driver, "%s(): " fmt "\n", \
-		__func__, ## args)
+#define PMD_DRV_LOG(level, ...) \
+	RTE_LOG_LINE_PREFIX(level, GVE_DRIVER, "%s(): ", __func__, __VA_ARGS__)
 
 #endif

--- a/gve_rx.c
+++ b/gve_rx.c
@@ -306,7 +306,7 @@ gve_rx_queue_setup(struct rte_eth_dev *dev, uint16_t queue_id,
 
 	/* Ring size is required to be a power of two. */
 	if (!rte_is_power_of_2(nb_desc)) {
-		PMD_DRV_LOG(ERR, "Invalid ring size %u. GVE ring size must be a power of 2.\n",
+		PMD_DRV_LOG(ERR, "Invalid ring size %u. GVE ring size must be a power of 2.",
 			    nb_desc);
 		return -EINVAL;
 	}

--- a/gve_rx.c
+++ b/gve_rx.c
@@ -304,11 +304,11 @@ gve_rx_queue_setup(struct rte_eth_dev *dev, uint16_t queue_id,
 	uint32_t mbuf_len;
 	int err = 0;
 
-	if (nb_desc != hw->rx_desc_cnt) {
+	if (nb_desc != hw->default_rx_desc_cnt) {
 		PMD_DRV_LOG(WARNING, "gve doesn't support nb_desc config, use hw nb_desc %u.",
-			    hw->rx_desc_cnt);
+			    hw->default_rx_desc_cnt);
 	}
-	nb_desc = hw->rx_desc_cnt;
+	nb_desc = hw->default_rx_desc_cnt;
 
 	/* Free memory if needed. */
 	if (dev->data->rx_queues[queue_id]) {

--- a/gve_rx.c
+++ b/gve_rx.c
@@ -386,7 +386,7 @@ gve_rx_queue_setup(struct rte_eth_dev *dev, uint16_t queue_id,
 	/* Allocate and register QPL for the queue. */
 	if (rxq->is_gqi_qpl) {
 		rxq->qpl = gve_setup_queue_page_list(hw, queue_id, true,
-						     hw->rx_data_slot_cnt);
+						     nb_desc);
 		if (!rxq->qpl) {
 			PMD_DRV_LOG(ERR,
 				    "Failed to alloc rx qpl for queue %hu.",

--- a/gve_rx_dqo.c
+++ b/gve_rx_dqo.c
@@ -161,7 +161,7 @@ gve_rx_burst_dqo(void *rx_queue, struct rte_mbuf **rx_pkts, uint16_t nb_pkts)
 		rxm->ol_flags = 0;
 		rxm->ol_flags |= RTE_MBUF_F_RX_RSS_HASH |
 				gve_parse_csum_ol_flags(rx_desc, rxq->hw);
-		rxm->hash.rss = rte_be_to_cpu_32(rx_desc->hash);
+		rxm->hash.rss = rte_le_to_cpu_32(rx_desc->hash);
 
 		rx_pkts[nb_rx++] = rxm;
 		bytes += pkt_len;

--- a/gve_rx_dqo.c
+++ b/gve_rx_dqo.c
@@ -195,14 +195,12 @@ gve_rx_burst_dqo(void *rx_queue, struct rte_mbuf **rx_pkts, uint16_t nb_pkts)
 
 	if (nb_rx > 0) {
 		rxq->rx_tail = rx_id;
-		if (rx_id_bufq != rxq->next_avail)
-			rxq->next_avail = rx_id_bufq;
-
-		gve_rx_refill_dqo(rxq);
+		rxq->next_avail = rx_id_bufq;
 
 		rxq->stats.packets += nb_rx;
 		rxq->stats.bytes += bytes;
 	}
+	gve_rx_refill_dqo(rxq);
 
 	return nb_rx;
 }

--- a/gve_rx_dqo.c
+++ b/gve_rx_dqo.c
@@ -132,6 +132,8 @@ gve_rx_burst_dqo(void *rx_queue, struct rte_mbuf **rx_pkts, uint16_t nb_pkts)
 		if (rx_desc->generation != rxq->cur_gen_bit)
 			break;
 
+		rte_io_rmb();
+
 		if (unlikely(rx_desc->rx_error)) {
 			rxq->stats.errors++;
 			continue;

--- a/gve_tx.c
+++ b/gve_tx.c
@@ -561,7 +561,7 @@ gve_tx_queue_setup(struct rte_eth_dev *dev, uint16_t queue_id, uint16_t nb_desc,
 
 	/* Ring size is required to be a power of two. */
 	if (!rte_is_power_of_2(nb_desc)) {
-		PMD_DRV_LOG(ERR, "Invalid ring size %u. GVE ring size must be a power of 2.\n",
+		PMD_DRV_LOG(ERR, "Invalid ring size %u. GVE ring size must be a power of 2.",
 			    nb_desc);
 		return -EINVAL;
 	}

--- a/gve_tx.c
+++ b/gve_tx.c
@@ -559,11 +559,11 @@ gve_tx_queue_setup(struct rte_eth_dev *dev, uint16_t queue_id, uint16_t nb_desc,
 	uint16_t free_thresh;
 	int err = 0;
 
-	if (nb_desc != hw->tx_desc_cnt) {
+	if (nb_desc != hw->default_tx_desc_cnt) {
 		PMD_DRV_LOG(WARNING, "gve doesn't support nb_desc config, use hw nb_desc %u.",
-			    hw->tx_desc_cnt);
+			    hw->default_tx_desc_cnt);
 	}
-	nb_desc = hw->tx_desc_cnt;
+	nb_desc = hw->default_tx_desc_cnt;
 
 	/* Free memory if needed. */
 	if (dev->data->tx_queues[queue_id]) {

--- a/gve_tx.c
+++ b/gve_tx.c
@@ -559,11 +559,12 @@ gve_tx_queue_setup(struct rte_eth_dev *dev, uint16_t queue_id, uint16_t nb_desc,
 	uint16_t free_thresh;
 	int err = 0;
 
-	if (nb_desc != hw->default_tx_desc_cnt) {
-		PMD_DRV_LOG(WARNING, "gve doesn't support nb_desc config, use hw nb_desc %u.",
-			    hw->default_tx_desc_cnt);
+	/* Ring size is required to be a power of two. */
+	if (!rte_is_power_of_2(nb_desc)) {
+		PMD_DRV_LOG(ERR, "Invalid ring size %u. GVE ring size must be a power of 2.\n",
+			    nb_desc);
+		return -EINVAL;
 	}
-	nb_desc = hw->default_tx_desc_cnt;
 
 	/* Free memory if needed. */
 	if (dev->data->tx_queues[queue_id]) {
@@ -633,6 +634,7 @@ gve_tx_queue_setup(struct rte_eth_dev *dev, uint16_t queue_id, uint16_t nb_desc,
 		txq->qpl = gve_setup_queue_page_list(hw, queue_id, false,
 						     hw->tx_pages_per_qpl);
 		if (!txq->qpl) {
+			err = -ENOMEM;
 			PMD_DRV_LOG(ERR, "Failed to alloc tx qpl for queue %hu.",
 				    queue_id);
 			goto err_iov_ring;

--- a/gve_tx.c
+++ b/gve_tx.c
@@ -690,7 +690,7 @@ gve_tx_queue_start(struct rte_eth_dev *dev, uint16_t tx_queue_id)
 
 	rte_write32(rte_cpu_to_be_32(GVE_IRQ_MASK), txq->ntfy_addr);
 
-	dev->data->rx_queue_state[tx_queue_id] = RTE_ETH_QUEUE_STATE_STARTED;
+	dev->data->tx_queue_state[tx_queue_id] = RTE_ETH_QUEUE_STATE_STARTED;
 
 	return 0;
 }

--- a/gve_tx_dqo.c
+++ b/gve_tx_dqo.c
@@ -392,7 +392,7 @@ gve_tx_queue_start_dqo(struct rte_eth_dev *dev, uint16_t tx_queue_id)
 
 	rte_write32(rte_cpu_to_be_32(GVE_IRQ_MASK), txq->ntfy_addr);
 
-	dev->data->rx_queue_state[tx_queue_id] = RTE_ETH_QUEUE_STATE_STARTED;
+	dev->data->tx_queue_state[tx_queue_id] = RTE_ETH_QUEUE_STATE_STARTED;
 
 	return 0;
 }

--- a/gve_tx_dqo.c
+++ b/gve_tx_dqo.c
@@ -138,7 +138,7 @@ gve_tx_burst_dqo(void *tx_queue, struct rte_mbuf **tx_pkts, uint16_t nb_pkts)
 		/* fill the last descriptor with End of Packet (EOP) bit */
 		txd->pkt.end_of_packet = 1;
 
-		if (ol_flags & GVE_TX_CKSUM_OFFLOAD_MASK)
+		if (ol_flags & GVE_TX_CKSUM_OFFLOAD_MASK_DQO)
 			txd->pkt.checksum_offload_enable = 1;
 
 		txq->nb_free -= nb_used;

--- a/gve_tx_dqo.c
+++ b/gve_tx_dqo.c
@@ -24,6 +24,8 @@ gve_tx_clean_dqo(struct gve_tx_queue *txq)
 	if (compl_desc->generation != txq->cur_gen_bit)
 		return;
 
+	rte_io_rmb();
+
 	compl_tag = rte_le_to_cpu_16(compl_desc->completion_tag);
 
 	aim_txq = txq->txqs[compl_desc->id];

--- a/gve_tx_dqo.c
+++ b/gve_tx_dqo.c
@@ -89,6 +89,7 @@ gve_tx_burst_dqo(void *tx_queue, struct rte_mbuf **tx_pkts, uint16_t nb_pkts)
 	uint16_t sw_id;
 	uint64_t bytes;
 	uint16_t first_sw_id;
+	uint8_t csum;
 
 	sw_ring = txq->sw_ring;
 	txr = txq->tx_ring;
@@ -114,6 +115,9 @@ gve_tx_burst_dqo(void *tx_queue, struct rte_mbuf **tx_pkts, uint16_t nb_pkts)
 		ol_flags = tx_pkt->ol_flags;
 		nb_used = tx_pkt->nb_segs;
 		first_sw_id = sw_id;
+
+		csum = !!(ol_flags & GVE_TX_CKSUM_OFFLOAD_MASK_DQO);
+
 		do {
 			if (sw_ring[sw_id] != NULL)
 				PMD_DRV_LOG(ERR, "Overwriting an entry in sw_ring");
@@ -126,6 +130,8 @@ gve_tx_burst_dqo(void *tx_queue, struct rte_mbuf **tx_pkts, uint16_t nb_pkts)
 			txd->pkt.dtype = GVE_TX_PKT_DESC_DTYPE_DQO;
 			txd->pkt.compl_tag = rte_cpu_to_le_16(first_sw_id);
 			txd->pkt.buf_size = RTE_MIN(tx_pkt->data_len, GVE_TX_MAX_BUF_SIZE_DQO);
+			txd->pkt.end_of_packet = 0;
+			txd->pkt.checksum_offload_enable = csum;
 
 			/* size of desc_ring and sw_ring could be different */
 			tx_id = (tx_id + 1) & mask;
@@ -137,9 +143,6 @@ gve_tx_burst_dqo(void *tx_queue, struct rte_mbuf **tx_pkts, uint16_t nb_pkts)
 
 		/* fill the last descriptor with End of Packet (EOP) bit */
 		txd->pkt.end_of_packet = 1;
-
-		if (ol_flags & GVE_TX_CKSUM_OFFLOAD_MASK_DQO)
-			txd->pkt.checksum_offload_enable = 1;
 
 		txq->nb_free -= nb_used;
 		txq->nb_used += nb_used;


### PR DESCRIPTION
This change includes the following commits:

```
net/gve/base: fix build with Fedora Rawhide
net/gve: add IO memory barriers before reading descriptors
net/gve: fix refill logic causing memory corruption
net/gve: always attempt Rx refill on DQ
net/gve: fix mbuf allocation memory leak for DQ Rx
net/gve: add packet type parsing to DQ format
net/gve: support TSO in DQO RDA
net/gve: fix Tx for chained mbuf
net/gve: fix queue setup and stop
drivers: use per line logging in helpers
drivers: remove redundant newline from logs
net/gve: fix Tx queue state on queue start
net/gve: support secondary process
net/gve: support modifying ring size in GQ format
net/gve: add minimum ring size device option
net/gve: remove explicit field for Rx pages per QPL
net/gve: add maximum ring size device option
net/gve: fix RSS hash endianness in DQO format
net/gve: change QPLs to be queue resources
memzone: remove unnecessary null checks
net/gve: add IPv4 checksum offloading capability
drivers: use stdatomic API
net/gve: enable Tx checksum offload for DQO
```